### PR TITLE
Clues optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ You can (optional) specify `passphrase` and `algo` (defaults to `aes192`) when y
 #### preCache
 When processing bulk-data it is often conventient to load data in bulk from cache as well.  By defining an object `perCache` in options you can supply any known information to avoid repeat calls to the db.  If a any requested key is found in `preCache` it is simply returned, otherwise the regular caching mechanism applies.   The objects in `preCache` need to adhere to the `cache-stampede` storage specification, i.e. the data should be under property `data`.
 
+#### clues resolution
+If you specify `clues: true` in options of either `.cached` or `.set` method,  the function supplied function will be returned to be resolved by [clues](https://github.com/ZJONSSON/clues) in the same `this` context as there the method was called.  It is important to `return` the cache-method so that the resolution machine can evaluate the formula that gets returned (see test/clues-test.js).  Failure to do so will result in an orphan record that will remain in `__caching__` state.
+
 #### Where do errors go?
 The default behaviour is to **not** cache errors. However, if any error object has a property `cache` set to `true`, then `cache-stampede` will save that error to cache and return it as rejected promise when it's requested again.  This can be very handy when you know an error represent an irrevocable state for a particular key.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-stampede",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "General caching that protects against a cache-stampede",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^2.9.25"
+    "bluebird": "~3.4.0",
+    "clues": "~3.5.0"
   },
   "devDependencies": {
     "mongodb": "^2.1.4",

--- a/stampede.js
+++ b/stampede.js
@@ -175,7 +175,7 @@ Stampede.prototype.decrypt = function(data,passphrase) {
   try {
     return JSON.parse(decipher.update(data,'base64','utf-8')+ decipher.final('utf-8'));
   } catch(e) {
-    if (e instanceof TypeError)
+    if (e instanceof TypeError || (e.message && e.message.indexOf('bad decrypt') !== -1))
       throw new Error('BAD_PASSPHRASE');
     else
       throw e;  

--- a/test/modules/clues-test.js
+++ b/test/modules/clues-test.js
@@ -1,0 +1,115 @@
+var assert = require('assert'),
+    Promise = require('bluebird'),
+    clues = require('clues');
+
+function shouldNotRun() { throw 'Should not run';}
+function shouldError() { throw 'Should have errored';}
+function errorMsg(msg) { return function(e) { assert.equal(e.message,msg);};}
+
+module.exports = function() {
+  function testFn() {
+    return Promise.delay(500)
+      .then(function() {
+        throw {message:'Error',cache:true};
+      });
+  }
+
+  before(function() {
+    this.cache.clues = true;
+    return Promise.all([
+      this.cache.adapter.remove('clues-testkey'),
+      this.cache.adapter.remove('clues-testkey2'),
+      this.cache.adapter.remove('clues-testkey3'),
+      this.cache.adapter.remove('clues-testkey4'),
+      this.cache.adapter.remove('clues-testkey5')
+    ]);
+  });
+
+  describe('Clues formula',function() {
+
+    /*it('regular formula returns value',function() {
+      var self = this;
+      var logic = {
+        value: function() {
+          return self.cache.cached('clues-testkey',function() { return 42;});
+        }
+      };
+      return clues(logic,'value').then(console.log)
+    });*/
+
+
+    it('works for value',function() {
+      var self = this;
+      var logic = {
+        value: function() {
+          return self.cache.cached('clues-testkey',42);
+        }
+      };
+      return clues(logic,'value')
+        .then(function(d) {
+          assert.equal(d,42);
+        },shouldError);
+
+    });
+
+
+    it('works for formula w/o arguments',function() {
+      var self = this;
+      var logic = {
+        value: function() {
+          return self.cache.cached('clues-testkey2',function() { return 42;},{clues: true});
+        }
+      };
+      return clues(logic,'value')
+        .then(function(d) {
+          assert.equal(d,42);
+        },shouldError);
+
+    });
+
+    it('works for formula w/arguments',function() {
+      var self = this;
+      var logic = {
+        a : function() {
+          return 41;
+        },
+        value: function() {
+          return self.cache.cached('clues-testkey3',function(a) { return a+1;},{clues: true});
+        }
+      };
+      return clues(logic,'value')
+        .then(function(d) {
+          assert.equal(d,42);
+        },shouldError);
+    });
+
+
+    it('works for array-defined-formula',function() {
+      var self = this;
+      var logic = {
+        a: 41,
+        value: function() {
+          return self.cache.cached('clues-testkey4',['a',function(d) { return d+1;}],{clues: true});
+        }
+      };
+      return clues(logic,'value')
+        .then(function(d) {
+          assert.equal(d,42);
+        },shouldError);
+    });
+
+
+    it('should return error as rejection',function() {
+      var self = this;
+      var logic = {
+        a: function() { throw 'FAILS';},
+        value: function() {
+          return self.cache.cached('clues-testkey5',function(a) { return a;},{clues: true});
+        }
+      };
+      return clues(logic,'value').then(shouldError,function(e) {
+        assert.equal(e.message,'FAILS');
+      });
+    });
+  });
+};


### PR DESCRIPTION
optional clues resolution
If you specify `clues: true` in options of either `.cached` or `.set` method,  the function supplied function will be returned to be resolved by [clues](https://github.com/ZJONSSON/clues) in the same `this` context as there the method was called.  It is important to `return` the cache-method so that the resolution machine can evaluate the formula that gets returned (see test/clues-test.js).  Failure to do so will result in an orphan record that will remain in `__caching__` state.