### PR TITLE
Fix zero coercion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-stampede",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "General caching that protects against a cache-stampede",
   "main": "index.js",
   "scripts": {

--- a/stampede.js
+++ b/stampede.js
@@ -40,8 +40,8 @@ Stampede.prototype.get = function(key,options,retry) {
           now = new Date();
 
       var expired = d.expiryTime && (now > +d.expiryTime),
-          aged = (!isNaN(options.maxAge) && (updated + options.maxAge) < now),
-          retryExpiry = (d.__caching__ && !isNaN(options.retryExpiry) && (updated + options.retryExpiry) < now);
+          aged = (!isNaN(options.maxAge) && (options.maxAge || options.maxAge === 0) && (updated + (+options.maxAge)) < now),
+          retryExpiry = (d.__caching__ && options.retryExpiry && !isNaN(options.retryExpiry) && (updated + (+options.retryExpiry)) < now);
 
       if (expired || aged || retryExpiry) {
         d = undefined;


### PR DESCRIPTION
We need to explicitly check if `options.maxAge` is either non-negative or explicitly === 0.  Otherwise other "zero" values, such as `null` and `false` would indicate instant purge of cache records, possibly by mistake