### PR TITLE
Dynamo objects

### DIFF
--- a/adapters/dynamodb.js
+++ b/adapters/dynamodb.js
@@ -8,13 +8,12 @@ module.exports = function(client,prefix) {
     get : function(key,options) {
       const query = {
         TableName: prefix,
-        KeyConditionExpression: "id = :id",
-        ExpressionAttributeValues: {
-          ":id": key
+        Key: {
+          "id":  key
         }
       };
-      return client.queryAsync(query)
-        .then(d => d.Items && d.Items[0] && JSON.parse(d.Items[0].ddata) || undefined);
+      return client.getAsync(query)
+        .then(d => d.Item && JSON.parse(d.Item.ddata) || undefined);
     },
 
     insert : function(key,d) {

--- a/adapters/dynamodb.js
+++ b/adapters/dynamodb.js
@@ -13,18 +13,39 @@ module.exports = function(client,prefix) {
         }
       };
       return client.getAsync(query)
-        .then(d => d.Item && JSON.parse(d.Item.ddata) || undefined);
+        .then(d => {
+          d = d.Item;
+          if (d) return {
+            _id: d.key,
+            data: d.cs_data,
+            __caching__: d.cs_caching,
+            info: d.cs_info,
+            updated : new Date(d.cs_updated),
+            encrypted: d.cs_encrypted,
+            error: d.cs_error,
+            expiryTime: d.cs_expiryTime
+          };
+        });
     },
 
     insert : function(key,d) {
+      d = {
+        id: key,
+        cs_data: d.data,
+        cs_caching: d.__caching__,
+        cs_updated: d.updated.valueOf(),
+        cs_info: d.info,
+        cs_encrypted: d.encrypted || false,
+        cs_error: d.error || false,
+        cs_expiryTime: d.expiryTime
+      };
+
       const query = {
         TableName: prefix,
-        Item: {
-          "id": key,
-          "ddata": JSON.stringify(d)
-        },
+        Item: d,
         ConditionExpression: "attribute_not_exists(id)"
       };
+      
       return client.putAsync(query)
         .catch(err => {
           if (err && err.code === 'ConditionalCheckFailedException')
@@ -40,9 +61,14 @@ module.exports = function(client,prefix) {
         Key: {
           "id": key,
         },
-        UpdateExpression: "set ddata = :d",
+        UpdateExpression: "set cs_data = :cs_data, cs_caching = :cs_caching, cs_encrypted = :cs_encrypted, cs_error = :cs_error, cs_updated =:cs_updated, cs_expiryTime = :cs_expiryTime",
         ExpressionAttributeValues: {
-          ":d": JSON.stringify(d)
+          ":cs_data": d.data,
+          ":cs_caching": d.__caching__,
+          ":cs_encrypted": d.encrypted ||false,
+          ":cs_error": d.error || false,
+          ":cs_updated": (d.updated || new Date()).valueOf(),
+          ":cs_expiryTime": (d.expiryTime && d.expiryTime.valueOf()  || 200000000000000)
         }
       };
       return client.updateAsync(query);

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  node:
+    version: 6.9.2
   services:
     - redis
   node:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,4 @@
 machine:
-  node:
-    version: 6.9.2
   services:
     - redis
   node:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-stampede",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "General caching that protects against a cache-stampede",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-stampede",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "General caching that protects against a cache-stampede",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "clues": "~3.5.15"
   },
   "devDependencies": {
-    "aws-sdk": "^2.9.0",
+    "aws-sdk": "^2.12.0",
     "mocha": "~3.0.2",
     "mongodb": "^2.2.11",
     "mongoose": "~4.6.4",

--- a/test/modules/delay-test.js
+++ b/test/modules/delay-test.js
@@ -51,14 +51,22 @@ module.exports = function() {
     });
 
     it('re-running with zero delay should fail MAXIMUM_RETRIES',function() {
+      var self = this;
       this.cache.cached('delay-testkey2',testFn);
-      return this.cache.cached('delay-testkey2',testFn,{retryDelay:0})
+      return Promise.delay(10)
+        .then(function() {
+          return self.cache.cached('delay-testkey2',testFn,{retryDelay:0});
+        })      
         .then(shouldError,errorMsg('MAXIMUM_RETRIES'));
     });
 
     it('rerunning with only one retry should fail',function() {
+      var self = this;
       this.cache.cached('delay-testkey3',testFn);
-      return this.cache.cached('delay-testkey3',testFn,{maxRetries:1})
+      return Promise.delay(10)
+        .then(function() {
+          return self.cache.cached('delay-testkey3',testFn,{maxRetries:1});
+        })
         .then(shouldError,errorMsg('MAXIMUM_RETRIES'));
     });
   });

--- a/test/modules/delay-test.js
+++ b/test/modules/delay-test.js
@@ -53,7 +53,7 @@ module.exports = function() {
     it('re-running with zero delay should fail MAXIMUM_RETRIES',function() {
       var self = this;
       this.cache.cached('delay-testkey2',testFn);
-      return Promise.delay(10)
+      return Promise.delay(50)
         .then(function() {
           return self.cache.cached('delay-testkey2',testFn,{retryDelay:0});
         })      
@@ -63,7 +63,7 @@ module.exports = function() {
     it('rerunning with only one retry should fail',function() {
       var self = this;
       this.cache.cached('delay-testkey3',testFn);
-      return Promise.delay(10)
+      return Promise.delay(50)
         .then(function() {
           return self.cache.cached('delay-testkey3',testFn,{maxRetries:1});
         })

--- a/test/modules/error-test.js
+++ b/test/modules/error-test.js
@@ -26,7 +26,7 @@ module.exports = function() {
     it('`set` should fail when db is still __caching__',function() {
       var self = this;
       self.cache.cached('error-testkey',testFn).catch(Object);
-      return Promise.delay(11)
+      return Promise.delay(50)
         .then(function() {
           return self.cache.set('error-testkey',function() { return 'New Value'; })
             .then(shouldError,errorMsg('KEY_EXISTS'));


### PR DESCRIPTION
* use get instead of query
* save as objects not string (using `cs_` prefix to avoid collisions)
* fix race condition in tests (guarantee second request fires *after* the first one)

Bumping minor version as this is a breaking change in the dynamodb (object instead of string)