### PR TITLE
Use redis for datastore insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Four basic database adapters are provided.
 * `require('cache-stampede').mongoose(collection_name,[options])`
 * `require('cache-stampede').redis(redis_client,[options])`
 * `require('cache-stampede').dynamodb(aws_client,[options])`
+* `require('cache-stampede').gcloudDatastore(datastore_client,redis_client,[options])`
 * `require('cache-stampede').file(directory,[options])`
 
-The relevant database libraries (mongo, mongodb, mongoose, redis and dynamodb) are only included as dev depdencies and are not installed through regular npm install.  You only need to install them if you want to run tests (mocha).  You can specify the particular `mongoose` object you want to use, as a property `mongoose` in `options`.  The file adapter maintains a list of files (named by the respective keys) the specified directory and does not require any third party database servers.  The `mongo` and `mongodb` adapters allows you to specify the collection as a promise to deliver a collection object (optional).
+The relevant database libraries (mongo, mongodb, mongoose, redis, datastore, and dynamodb) are only included as dev depdencies and are not installed through regular npm install.  You only need to install them if you want to run tests (mocha).  You can specify the particular `mongoose` object you want to use, as a property `mongoose` in `options`.  The file adapter maintains a list of files (named by the respective keys) the specified directory and does not require any third party database servers.  The `mongo` and `mongodb` adapters allows you to specify the collection as a promise to deliver a collection object (optional).
 
 A special adapter called `mongoHistory` retains historical cached values in the collection instead of deleting them. The adapter defines a custom method `getHistory` that returns all records for a particular key.
+
+The gcloud datastore adapter `gcloudDatastore` uses redis to control locking, so both clients must be specified.
 
 This library can be initialized with a custom adapter.  A custom adapter needs to provide `get`, `insert`, `update` and `remove` functions which should return Promise A+ compliant promises.  The `insert` method should return `KEY_EXISTS` error if a key already exists in the datastore and the `get` method should return `null` or `undefined` if a key was not found.  Please note:  
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "clues": "~3.5.15"
   },
   "devDependencies": {
+    "@google-cloud/datastore": "1.0.1",
     "aws-sdk": "^2.12.0",
-    "@google-cloud/datastore": "^0.7.0",
     "mocha": "~3.0.2",
     "mongodb": "^2.2.11",
     "mongoose": "~4.6.4",

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -5,7 +5,8 @@ var fs = require('fs'),
     Promise = require('bluebird'),
     mongoose = require('mongoose'),
     AWS = require('aws-sdk'),
-    dynamodbSchema = require('./dynamodb_schema');
+    redis = require('redis').createClient(),
+    dynamodbSchema = require('./dynamodb_schema'),
     gcloudDatastore = require('@google-cloud/datastore')({
       projectId: process.env.DATASTORE_PROJECT_ID,
       promise: Promise,
@@ -55,14 +56,11 @@ var caches = {
 
   mongoose : () =>  stampede.mongoose('stampede_tests',{mongoose:mongoose}),
 
-  redis : () => stampede.redis(
-    require('redis')
-      .createClient()
-  ),
+  redis : () => stampede.redis(redis),
 
   dynamodb : () => stampede.dynamodb(new AWS.DynamoDB.DocumentClient()),
 
-  gcloudDatastore : () => stampede.gcloudDatastore(gcloudDatastore),
+  gcloudDatastore : () => stampede.gcloudDatastore(gcloudDatastore,redis),
 
   file : () => stampede.file(path.join(__dirname,'filecache'))
 };


### PR DESCRIPTION
```
 // GCloud Datastore Adapter
 //
 // Uses redis to control overwrites on insert,
 // because datastore can only run one transaction on an entity per second
 // https://cloud.google.com/appengine/articles/scaling/contention
 //
 // Info properties must be serialized top level because datastore does not
 // permit indexing properties contained within a property that is excluded from
 // indexing. And the entire object is too large to be indexed as a whole.
```