### PR TITLE
Fix adapter args

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Four basic database adapters are provided.
 * `require('cache-stampede').mongoose(collection_name,[options])`
 * `require('cache-stampede').redis(redis_client,[options])`
 * `require('cache-stampede').dynamodb(aws_client,[options])`
-* `require('cache-stampede').gcloudDatastore(datastore_client,redis_client,[options])`
+* `require('cache-stampede').gcloudDatastore([datastore_client,redis_client],[options])`
 * `require('cache-stampede').file(directory,[options])`
 
 The relevant database libraries (mongo, mongodb, mongoose, redis, datastore, and dynamodb) are only included as dev depdencies and are not installed through regular npm install.  You only need to install them if you want to run tests (mocha).  You can specify the particular `mongoose` object you want to use, as a property `mongoose` in `options`.  The file adapter maintains a list of files (named by the respective keys) the specified directory and does not require any third party database servers.  The `mongo` and `mongodb` adapters allows you to specify the collection as a promise to deliver a collection object (optional).

--- a/adapters/gcloudDatastore.js
+++ b/adapters/gcloudDatastore.js
@@ -48,7 +48,9 @@ const deSerialize = d => {
 
 const Promise = require('bluebird');
 
-module.exports = function(datastoreClient,redisClient,prefix) {  
+module.exports = function(clients,prefix) {
+  let datastoreClient = clients[0];
+  let redisClient = clients[1];
   Promise.promisifyAll(redisClient);
   prefix = prefix || 'cache';
   return {

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -60,7 +60,7 @@ var caches = {
 
   dynamodb : () => stampede.dynamodb(new AWS.DynamoDB.DocumentClient()),
 
-  gcloudDatastore : () => stampede.gcloudDatastore(gcloudDatastore,redis),
+  gcloudDatastore : () => stampede.gcloudDatastore([gcloudDatastore,redis]),
 
   file : () => stampede.file(path.join(__dirname,'filecache'))
 };


### PR DESCRIPTION
gcloud datastore prefix aka collection name has been ignored
since the redis addition